### PR TITLE
Load Environment Variables before everything else is loaded

### DIFF
--- a/src/app/[locale]/asset/_components/RedirectToViewer.tsx
+++ b/src/app/[locale]/asset/_components/RedirectToViewer.tsx
@@ -26,15 +26,14 @@ export const RedirectToViewer = () => {
     useAsyncEffect(async () => {
         try {
             setIsLoading(true);
-            if (env.DISCOVERY_API_URL != '') {
-                await navigateToViewerOfAsset(decodeURIComponent(assetIdParam ?? ''));
-            }
+            await navigateToViewerOfAsset(decodeURIComponent(assetIdParam ?? ''));
+            
         } catch (e) {
             setIsLoading(false);
             setIsError(true);
             showError(e, notificationSpawner);
         }
-    }, [env]);
+    }, []);
 
     async function navigateToViewerOfAsset(assetId: string | undefined): Promise<void> {
         const aasIds = await getAasIdsOfAsset(assetId);

--- a/src/app/[locale]/list/_components/AASListView.tsx
+++ b/src/app/[locale]/list/_components/AASListView.tsx
@@ -70,17 +70,15 @@ export const AASListView = () => {
     useAsyncEffect(async () => {
         try {
             setIsLoadingList(true);
-            if (env.MNESTIX_BACKEND_API_URL != '') {
-                const list = await aasListClient.getAasListEntries();
-                setAasList(list);
-                if (!productClassFilterValue) setAasListFiltered(list);
-            }
+            const list = await aasListClient.getAasListEntries();
+            setAasList(list);
+            if (!productClassFilterValue) setAasListFiltered(list);
         } catch (e) {
             showError(e, notificationSpawner);
         } finally {
             setIsLoadingList(false);
         }
-    }, [env]);
+    }, []);
 
     /**
      * Creates the ProductClass Filter values.

--- a/src/app/[locale]/viewer/[base64AasId]/page.tsx
+++ b/src/app/[locale]/viewer/[base64AasId]/page.tsx
@@ -42,20 +42,19 @@ export default function Page() {
             try {
                 setIsLoadingAas(true);
                 if (aas === null) {
-                    if (env.AAS_REPO_API_URL != '' || env.REGISTRY_API_URL != '') {
-                        const aasIdDecoded = safeBase64Decode(base64AasId);
-                        const registrySearchResult = await handleAasRegistrySearch(aasIdDecoded);
-                        if (registrySearchResult != null) {
-                            setAas(registrySearchResult.registryAas as AssetAdministrationShell);
-                            setRegistryAasData({
-                                submodelDescriptors: registrySearchResult?.registryAasData?.submodelDescriptors,
-                                aasRegistryRepositoryOrigin: registrySearchResult?.registryAasData?.aasRegistryRepositoryOrigin });
-                            setAasData(registrySearchResult.registryAas as AssetAdministrationShell);
-                        } else {
-                            const shell = await repositoryClient.getAssetAdministrationShellById(base64AasId as string);
-                            setAas(shell);
-                            setAasData(shell);
-                        }
+                    const aasIdDecoded = safeBase64Decode(base64AasId);
+                    const registrySearchResult = await handleAasRegistrySearch(aasIdDecoded);
+                    if (registrySearchResult != null) {
+                        setAas(registrySearchResult.registryAas as AssetAdministrationShell);
+                        setRegistryAasData({
+                            submodelDescriptors: registrySearchResult?.registryAasData?.submodelDescriptors,
+                            aasRegistryRepositoryOrigin: registrySearchResult?.registryAasData?.aasRegistryRepositoryOrigin });
+                        setAasData(registrySearchResult.registryAas as AssetAdministrationShell);
+                    } else {
+                        const shell = await repositoryClient.getAssetAdministrationShellById(base64AasId as string);
+                        setAas(shell);
+                        setAasData(shell);
+                    
                     }
                 } else {
                     setAasData(aas);

--- a/src/app/env/provider.tsx
+++ b/src/app/env/provider.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useState } from 'react';
 import { EnvironmentalVariables, getEnv } from './env';
 import { useAsyncEffect } from 'lib/hooks/UseAsyncEffect';
+import {CenteredLoadingSpinner} from "../../components/basics/CenteredLoadingSpinner";
 
 const initialValues: EnvironmentalVariables = {
     AAS_LIST_FEATURE_FLAG: false,
@@ -29,12 +30,14 @@ export const EnvProvider = ({
     children: React.ReactNode;
 }>) => {
     const [env, setEnv] = useState<EnvironmentalVariables>(initialValues);
-
+    const [renderChildren, setChildren] = useState<boolean>(false);
     useAsyncEffect(async () => {
         const env = await getEnv();
         setEnv(env);
+        setChildren(true);
     }, []);
-    return <EnvContext.Provider value={env}>{children}</EnvContext.Provider>;
+
+    return renderChildren ? <EnvContext.Provider value={env}>{children}</EnvContext.Provider> : <CenteredLoadingSpinner/>;
 };
 
 export const useEnv = () => {


### PR DESCRIPTION
This avoids unecessary errors of unloaded env vars when loading the app for the first time (e.g. when using the /asset endpoint or the settings)