### PR TITLE
fix(github-runner): The github runner will use and push the correct docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,24 +45,15 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASS }}
 
-      - name: check docker status
-        run: docker images && echo -e "\n -----------------------------------------------------------\n" && docker ps
-
       # Build Docker image
       - name: Build image
         id: build
         run: docker compose build mnestix-browser
 
-      - name: check docker status
-        run: docker images && echo -e "\n -----------------------------------------------------------\n" && docker ps
-
       - name: E2E test
         id: test
         run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests up -d &&
           docker compose -f compose.yml -f docker-compose/compose.test.yml attach cypress-test
-
-      - name: check docker status
-        run: docker images && echo -e "\n -----------------------------------------------------------\n" && docker ps
 
       - name: E2E test collect artifact
         id: test_artifact
@@ -82,7 +73,6 @@ jobs:
 
       - name: Push Image to development
         id: push-dev
-        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/staging'
         env:
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: docker tag mnestix/$IMAGE_NAME mnestixcr.azurecr.io/$IMAGE_NAME:$BRANCH_NAME &&

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,10 +45,16 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASS }}
 
+      - name: check docker status
+        run: docker images && echo -e "\n -----------------------------------------------------------\n" && docker ps
+
       # Build Docker image
       - name: Build image
         id: build
         run: docker compose build mnestix-browser
+
+      - name: check docker status
+        run: docker images && echo -e "\n -----------------------------------------------------------\n" && docker ps
 
       - name: E2E test
         id: test
@@ -56,6 +62,9 @@ jobs:
           docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests down &&
           docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests up -d &&
           docker compose -f compose.yml -f docker-compose/compose.test.yml attach cypress-test
+
+      - name: check docker status
+        run: docker images && echo -e "\n -----------------------------------------------------------\n" && docker ps
 
       - name: E2E test collect artifact
         id: test_artifact

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,9 +58,7 @@ jobs:
 
       - name: E2E test
         id: test
-        run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests pull &&
-          docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests down &&
-          docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests up -d &&
+        run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests up -d &&
           docker compose -f compose.yml -f docker-compose/compose.test.yml attach cypress-test
 
       - name: check docker status

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Push Image to development
         id: push-dev
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/staging'
         env:
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: docker tag mnestix/$IMAGE_NAME mnestixcr.azurecr.io/$IMAGE_NAME:$BRANCH_NAME &&


### PR DESCRIPTION
# Description

The github runner was pulling all images and was overwriting the freshly build mnestix-browser image.
Because each action is started with a blank slate, the pull command is not required. docker compose up will pull the missing images .

Fixes # (MNES-1168)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] My changes generate no new warnings
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
