### PR TITLE
fix(versioning): fix version number not displaying when authenticatio…

### DIFF
--- a/src/layout/menu/MainMenu.tsx
+++ b/src/layout/menu/MainMenu.tsx
@@ -202,12 +202,11 @@ export default function MainMenu() {
                 >
                     {`Copyright © ${new Date().getFullYear()} XITASO GmbH`}
                 </Typography>
-                {!useAuthentication ||
-                    (!auth.isLoggedIn && (
-                        <Typography align="left" paddingLeft="16px" paddingBottom="10px" style={{ opacity: '0.6' }}>
-                            {versionString}
-                        </Typography>
-                    ))}
+                {(!useAuthentication || !auth.isLoggedIn) && (
+                    <Typography align="left" paddingLeft="16px" paddingBottom="10px" style={{ opacity: '0.6' }}>
+                        {versionString}
+                    </Typography>
+                )}
                 {useAuthentication && auth.isLoggedIn && (
                     <Box>
                         <List>


### PR DESCRIPTION
# Description

Previously, the version number was not displayed when turning off the authentication due to a small logic error. 

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
