### PR TITLE
Fix(compare view) images in comparison view now redirect to the correct aas detail page

### DIFF
--- a/cypress/e2e/compareViewTest.spec.js
+++ b/cypress/e2e/compareViewTest.spec.js
@@ -160,6 +160,31 @@ describe('Test compare feature view', function () {
             cy.getByTestId('compare-value').should('not.exist');
         });
     });
+
+    it('Clicking the image of an AAS in compare view redirects to the detail page', function () {
+        cy.setResolution(resolutions[0]);
+        
+        // go to compare view with all three test data
+        const url = `/compare?aasId=${compareAAS[0].id}&aasId=${compareAAS[1].id}&aasId=${compareAAS[2].id}`;
+        cy.visit(url);
+        cy.getByTestId('compare-aas-2').should('be.visible');
+        
+        // click second image
+        cy.getByTestId('compare-aas-1')
+            .findByTestId('image-with-fallback')
+            .click();
+        
+        // check if url is correct
+        const b64Url = btoa(compareAAS[1].id)
+            .replace(/=*$/, '');
+        cy.url().should('contain', `/viewer/${b64Url}`);
+            
+        // check if loaded aas id is correct
+        cy.getByTestId('aas-data')
+            .findByTestId('data-row-value')
+            .should('contain', compareAAS[1].id);
+    });
+    
     after(function () {
         cy.deleteCompareMockData();
     });

--- a/src/app/[locale]/list/_components/StyledImageWithFallBack.tsx
+++ b/src/app/[locale]/list/_components/StyledImageWithFallBack.tsx
@@ -40,6 +40,7 @@ export const ImageWithFallback = (props: StyledImageWithFallBackProps) => {
                 }
             }}
             style={{ cursor: onClickHandler ? 'pointer' : 'auto' }}
+            data-testid='image-with-fallback'
         />
     );
 

--- a/src/app/[locale]/viewer/_components/AASOverviewCard.tsx
+++ b/src/app/[locale]/viewer/_components/AASOverviewCard.tsx
@@ -22,7 +22,7 @@ import { encodeBase64 } from 'lib/util/Base64Util';
 import { useAsyncEffect } from 'lib/hooks/UseAsyncEffect';
 import { useRouter } from 'next/navigation';
 import { useApis } from 'components/azureAuthentication/ApiProvider';
-import { useRegistryAasState } from 'components/contexts/CurrentAasContext';
+import { useAasState, useRegistryAasState } from 'components/contexts/CurrentAasContext';
 import { AssetAdministrationShellRepositoryApi } from 'lib/api/basyx-v3/api';
 import { ImageWithFallback } from 'app/[locale]/list/_components/StyledImageWithFallBack';
 import { performgetAasThumbnailFromAllRepos } from 'lib/services/MultipleRepositorySearch/MultipleRepositorySearchActions';
@@ -64,6 +64,7 @@ export function AASOverviewCard(props: AASOverviewCardProps) {
     const [productImageUrl, setProductImageUrl] = useState<string | undefined>('');
     const { repositoryClient } = useApis();
     const [registryAasData] = useRegistryAasState();
+    const [, setAasState] = useAasState();
 
     async function createAndSetUrlForImageFile() {
         if (!props.aas) return;
@@ -120,7 +121,11 @@ export function AASOverviewCard(props: AASOverviewCardProps) {
     };
 
     const navigateToAas = () => {
-        if (props.imageLinksToDetail && props.aas) navigate.push(`/viewer/${encodeBase64(props.aas.id)}`);
+        if (props.imageLinksToDetail && props.aas) {
+            setAasState(props.aas)
+            const url = `/viewer/${encodeBase64(props.aas.id)}`;
+            navigate.push(url);
+        }
     };
 
     const aasInfo = (


### PR DESCRIPTION
# Description

When clicking on an AAS image in compare view, we now set the AAS context, before redirecting.
Also added a simple E2E test.

Fixes # (Issue)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
