### PR TITLE
refactor(api-calls): Pull static methods out of Wrapper class

### DIFF
--- a/src/app/[locale]/asset/_components/RedirectToViewer.tsx
+++ b/src/app/[locale]/asset/_components/RedirectToViewer.tsx
@@ -11,7 +11,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import AssetNotFound from 'components/basics/AssetNotFound';
 import { useAasState } from 'components/contexts/CurrentAasContext';
 import { performDiscoveryAasSearch } from 'lib/services/search-actions/searchActions';
-import { ApiResponseWrapperUtil } from 'lib/services/apiResponseWrapper';
+import { WrapSuccess } from 'lib/services/apiResponseWrapper';
 import { LocalizedError } from 'lib/util/LocalizedError';
 import { messages } from 'lib/i18n/localization';
 
@@ -52,7 +52,7 @@ export const RedirectToViewer = () => {
         }
         const response = await performDiscoveryAasSearch(assetId);
         if (response.isSuccess) return response;
-        return ApiResponseWrapperUtil.fromSuccess([]);
+        return WrapSuccess([]);
     }
 
     function assertAtLeastOneAasIdExists(aasIds: string[]) {

--- a/src/app/[locale]/asset/_components/RedirectToViewer.tsx
+++ b/src/app/[locale]/asset/_components/RedirectToViewer.tsx
@@ -11,7 +11,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import AssetNotFound from 'components/basics/AssetNotFound';
 import { useAasState } from 'components/contexts/CurrentAasContext';
 import { performDiscoveryAasSearch } from 'lib/services/search-actions/searchActions';
-import { WrapSuccess } from 'lib/services/apiResponseWrapper';
+import { wrapSuccess } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { LocalizedError } from 'lib/util/LocalizedError';
 import { messages } from 'lib/i18n/localization';
 
@@ -52,7 +52,7 @@ export const RedirectToViewer = () => {
         }
         const response = await performDiscoveryAasSearch(assetId);
         if (response.isSuccess) return response;
-        return WrapSuccess([]);
+        return wrapSuccess([]);
     }
 
     function assertAtLeastOneAasIdExists(aasIds: string[]) {

--- a/src/components/contexts/CompareAasContext.tsx
+++ b/src/components/contexts/CompareAasContext.tsx
@@ -1,4 +1,4 @@
-﻿import { AssetAdministrationShell, Reference, Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
+﻿import { AssetAdministrationShell, Reference } from '@aas-core-works/aas-core3.0-typescript/types';
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react';
 import { SubmodelCompareData } from 'lib/types/SubmodelCompareData';
 import { generateSubmodelCompareData, isCompareData, isCompareDataRecord } from 'lib/util/CompareAasUtil';
@@ -6,8 +6,6 @@ import { getSubmodelFromSubmodelDescriptor, performFullAasSearch } from 'lib/ser
 import { SubmodelDescriptor } from 'lib/types/registryServiceTypes';
 import { getSubmodelDescriptorsById } from 'lib/services/submodelRegistryApiActions';
 import { getSubmodelById } from 'lib/services/repository-access/repositorySearchActions';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
-import { AasSearchResult } from 'lib/services/search-actions/AasSearcher';
 
 type CompareAasContextType = {
     compareAas: AssetAdministrationShell[];
@@ -73,7 +71,7 @@ export const CompareAasContextProvider = (props: PropsWithChildren) => {
         const aasList: AssetAdministrationShell[] = [];
         let compareDataTemp: SubmodelCompareData[] = [];
         for (const aasId of input as string[]) {
-            const {isSuccess, result } = await performFullAasSearch(aasId);
+            const { isSuccess, result } = await performFullAasSearch(aasId);
             if (isSuccess && result.aas) {
                 aasList.push(result.aas);
                 if (result.aas.submodels) {

--- a/src/lib/api/basyx-v3/api.ts
+++ b/src/lib/api/basyx-v3/api.ts
@@ -10,7 +10,7 @@ import {
     INullableAasRepositoryEntries,
     SubmodelRepositoryApiInMemory,
 } from 'lib/api/basyx-v3/apiInMemory';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 const BASE_PATH = '/'.replace(/\/+$/, '');
 

--- a/src/lib/api/basyx-v3/apiInMemory.ts
+++ b/src/lib/api/basyx-v3/apiInMemory.ts
@@ -1,7 +1,7 @@
 import { IAssetAdministrationShellRepositoryApi, ISubmodelRepositoryApi } from 'lib/api/basyx-v3/apiInterface';
 import { AssetAdministrationShell, Reference, Submodel } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
 import { decodeBase64, encodeBase64 } from 'lib/util/Base64Util';
-import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapResponse } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, wrapErrorCode, wrapResponse } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export interface INullableAasRepositoryEntries {
     repositoryUrl: string;
@@ -32,13 +32,13 @@ export class AssetAdministrationShellRepositoryApiInMemory implements IAssetAdmi
                 const isInDefaultRepository = entry.repositoryUrl === defaultRepositoryUrl;
                 if (isInDefaultRepository || !isSearchingInDefaultRepository) {
                     const response = new Response(JSON.stringify(entry.aas));
-                    return await WrapResponse<AssetAdministrationShell>(response);
+                    return await wrapResponse<AssetAdministrationShell>(response);
                 }
             }
         }
         const targetRepositoryKind = isSearchingInDefaultRepository ? 'default' : 'foreign';
         return Promise.resolve(
-            WrapErrorCode(
+            wrapErrorCode(
                 ApiResultStatus.NOT_FOUND,
                 'no aas found in the ' +
                     targetRepositoryKind +
@@ -83,11 +83,11 @@ export class SubmodelRepositoryApiInMemory implements ISubmodelRepositoryApi {
         for (const submodel of this.submodelsSavedInTheRepository) {
             if (encodeBase64(submodel.id) === submodelId) {
                 const response = new Response(JSON.stringify(submodel));
-                return await WrapResponse<Submodel>(response);
+                return await wrapResponse<Submodel>(response);
             }
         }
         return Promise.resolve(
-            WrapErrorCode(
+            wrapErrorCode(
                 ApiResultStatus.NOT_FOUND,
                 'no submodel found in the default repository for submodelId: ' + submodelId,
             ),

--- a/src/lib/api/basyx-v3/apiInMemory.ts
+++ b/src/lib/api/basyx-v3/apiInMemory.ts
@@ -1,7 +1,7 @@
 import { IAssetAdministrationShellRepositoryApi, ISubmodelRepositoryApi } from 'lib/api/basyx-v3/apiInterface';
 import { AssetAdministrationShell, Reference, Submodel } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
 import { decodeBase64, encodeBase64 } from 'lib/util/Base64Util';
-import { ApiResponseWrapper, ApiResponseWrapperUtil, ApiResultStatus } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapResponse } from 'lib/services/apiResponseWrapper';
 
 export interface INullableAasRepositoryEntries {
     repositoryUrl: string;
@@ -32,22 +32,29 @@ export class AssetAdministrationShellRepositoryApiInMemory implements IAssetAdmi
                 const isInDefaultRepository = entry.repositoryUrl === defaultRepositoryUrl;
                 if (isInDefaultRepository || !isSearchingInDefaultRepository) {
                     const response = new Response(JSON.stringify(entry.aas));
-                    return await ApiResponseWrapperUtil.fromResponse<AssetAdministrationShell>(response);
+                    return await WrapResponse<AssetAdministrationShell>(response);
                 }
             }
         }
         const targetRepositoryKind = isSearchingInDefaultRepository ? 'default' : 'foreign';
-        return Promise.resolve(ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND,
-            'no aas found in the ' +
-            targetRepositoryKind +
-            ' repository for aasId: ' +
-            aasId +
-            ', which is :' +
-            decodeBase64(aasId) +
-            ' encoded in base64'));
+        return Promise.resolve(
+            WrapErrorCode(
+                ApiResultStatus.NOT_FOUND,
+                'no aas found in the ' +
+                    targetRepositoryKind +
+                    ' repository for aasId: ' +
+                    aasId +
+                    ', which is :' +
+                    decodeBase64(aasId) +
+                    ' encoded in base64',
+            ),
+        );
     }
 
-    async getSubmodelReferencesFromShell(_aasId: string, _options?: object | undefined): Promise<ApiResponseWrapper<Reference[]>> {
+    async getSubmodelReferencesFromShell(
+        _aasId: string,
+        _options?: object | undefined,
+    ): Promise<ApiResponseWrapper<Reference[]>> {
         throw new Error('Method not implemented.');
     }
 
@@ -76,14 +83,14 @@ export class SubmodelRepositoryApiInMemory implements ISubmodelRepositoryApi {
         for (const submodel of this.submodelsSavedInTheRepository) {
             if (encodeBase64(submodel.id) === submodelId) {
                 const response = new Response(JSON.stringify(submodel));
-                return await ApiResponseWrapperUtil.fromResponse<Submodel>(response);
+                return await WrapResponse<Submodel>(response);
             }
         }
         return Promise.resolve(
-            ApiResponseWrapperUtil.fromErrorCode(
+            WrapErrorCode(
                 ApiResultStatus.NOT_FOUND,
-                'no submodel found in the default repository for submodelId: ' + submodelId
-            )
+                'no submodel found in the default repository for submodelId: ' + submodelId,
+            ),
         );
     }
 

--- a/src/lib/api/basyx-v3/apiInterface.ts
+++ b/src/lib/api/basyx-v3/apiInterface.ts
@@ -1,6 +1,6 @@
 import { AssetAdministrationShell, Reference } from '@aas-core-works/aas-core3.0-typescript/types';
 import { Submodel } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export interface IAssetAdministrationShellRepositoryApi {
     /**

--- a/src/lib/api/discovery-service-api/discoveryServiceApi.ts
+++ b/src/lib/api/discovery-service-api/discoveryServiceApi.ts
@@ -1,7 +1,7 @@
 import { encodeBase64 } from 'lib/util/Base64Util';
 import { DiscoveryEntry, IDiscoveryServiceApi } from 'lib/api/discovery-service-api/discoveryServiceApiInterface';
 import { DiscoveryServiceApiInMemory } from 'lib/api/discovery-service-api/discoveryServiceApiInMemory';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export class DiscoveryServiceApi implements IDiscoveryServiceApi {
     baseUrl: string;

--- a/src/lib/api/discovery-service-api/discoveryServiceApiInMemory.ts
+++ b/src/lib/api/discovery-service-api/discoveryServiceApiInMemory.ts
@@ -1,5 +1,5 @@
 import { DiscoveryEntry, IDiscoveryServiceApi } from 'lib/api/discovery-service-api/discoveryServiceApiInterface';
-import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapSuccess } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, wrapErrorCode, wrapSuccess } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export class DiscoveryServiceApiInMemory implements IDiscoveryServiceApi {
     private discoveryEntries: { assetId: string; aasIds: string[] }[];
@@ -18,13 +18,13 @@ export class DiscoveryServiceApiInMemory implements IDiscoveryServiceApi {
         for (const discoveryEntry of this.discoveryEntries) {
             if (discoveryEntry.assetId === assetId)
                 return Promise.resolve(
-                    WrapSuccess({
+                    wrapSuccess({
                         paging_metadata: '',
                         result: discoveryEntry.aasIds,
                     }),
                 );
         }
-        return Promise.resolve(WrapErrorCode(ApiResultStatus.NOT_FOUND, 'not found'));
+        return Promise.resolve(wrapErrorCode(ApiResultStatus.NOT_FOUND, 'not found'));
     }
 
     async deleteAllAssetLinksById(_aasId: string): Promise<ApiResponseWrapper<void>> {

--- a/src/lib/api/discovery-service-api/discoveryServiceApiInMemory.ts
+++ b/src/lib/api/discovery-service-api/discoveryServiceApiInMemory.ts
@@ -1,5 +1,5 @@
 import { DiscoveryEntry, IDiscoveryServiceApi } from 'lib/api/discovery-service-api/discoveryServiceApiInterface';
-import { ApiResponseWrapper, ApiResponseWrapperUtil, ApiResultStatus } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapSuccess } from 'lib/services/apiResponseWrapper';
 
 export class DiscoveryServiceApiInMemory implements IDiscoveryServiceApi {
     private discoveryEntries: { assetId: string; aasIds: string[] }[];
@@ -12,22 +12,28 @@ export class DiscoveryServiceApiInMemory implements IDiscoveryServiceApi {
         throw new Error('Method not implemented.');
     }
 
-    async getAasIdsByAssetId(assetId: string): Promise<ApiResponseWrapper<{ paging_metadata: string; result: string[] }>> {
+    async getAasIdsByAssetId(
+        assetId: string,
+    ): Promise<ApiResponseWrapper<{ paging_metadata: string; result: string[] }>> {
         for (const discoveryEntry of this.discoveryEntries) {
             if (discoveryEntry.assetId === assetId)
-                return Promise.resolve(ApiResponseWrapperUtil.fromSuccess({
-                    paging_metadata: '',
-                    result: discoveryEntry.aasIds,
-                }));
+                return Promise.resolve(
+                    WrapSuccess({
+                        paging_metadata: '',
+                        result: discoveryEntry.aasIds,
+                    }),
+                );
         }
-        return Promise.resolve(ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'not found'));
+        return Promise.resolve(WrapErrorCode(ApiResultStatus.NOT_FOUND, 'not found'));
     }
 
     async deleteAllAssetLinksById(_aasId: string): Promise<ApiResponseWrapper<void>> {
         throw new Error('Method not implemented.');
     }
 
-    async getAllAssetAdministrationShellIdsByAssetLink(_assetIds: { name: string; value: string }[]): Promise<ApiResponseWrapper<{ paging_metadata: string; result: string[] }>> {
+    async getAllAssetAdministrationShellIdsByAssetLink(
+        _assetIds: { name: string; value: string }[],
+    ): Promise<ApiResponseWrapper<{ paging_metadata: string; result: string[] }>> {
         throw new Error('Method not implemented.');
     }
 
@@ -35,7 +41,10 @@ export class DiscoveryServiceApiInMemory implements IDiscoveryServiceApi {
         throw new Error('Method not implemented.');
     }
 
-    async postAllAssetLinksById(_aasId: string, _assetLinks: DiscoveryEntry[]): Promise<ApiResponseWrapper<DiscoveryEntry[]>> {
+    async postAllAssetLinksById(
+        _aasId: string,
+        _assetLinks: DiscoveryEntry[],
+    ): Promise<ApiResponseWrapper<DiscoveryEntry[]>> {
         throw new Error('Method not implemented.');
     }
 }

--- a/src/lib/api/discovery-service-api/discoveryServiceApiInterface.ts
+++ b/src/lib/api/discovery-service-api/discoveryServiceApiInterface.ts
@@ -1,4 +1,4 @@
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export type DiscoveryEntry = {
     name: string;

--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -1,6 +1,6 @@
-import { getServerSession } from 'next-auth';
+﻿import { getServerSession } from 'next-auth';
 import { performServerFetch, performServerFetchLegacy } from 'lib/api/serverFetch';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { authOptions } from 'authConfig';
 
 const initializeRequestOptions = async (bearerToken: string, init?: RequestInit) => {

--- a/src/lib/api/registry-service-api/registryServiceApi.ts
+++ b/src/lib/api/registry-service-api/registryServiceApi.ts
@@ -6,7 +6,7 @@ import {
     RegistryServiceApiInMemory,
 } from 'lib/api/registry-service-api/registryServiceApiInMemory';
 import { AssetAdministrationShell } from '@aas-core-works/aas-core3.0-typescript/types';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export class RegistryServiceApi implements IRegistryServiceApi {
     baseUrl: string;

--- a/src/lib/api/registry-service-api/registryServiceApiInMemory.ts
+++ b/src/lib/api/registry-service-api/registryServiceApiInMemory.ts
@@ -1,7 +1,7 @@
 import { IRegistryServiceApi } from 'lib/api/registry-service-api/registryServiceApiInterface';
 import { AssetAdministrationShellDescriptor } from 'lib/types/registryServiceTypes';
 import { AssetAdministrationShell } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
-import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapResponse } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, wrapErrorCode, wrapResponse } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export interface INullableAasRegistryEndpointEntries {
     endpoint: URL | string;
@@ -30,11 +30,11 @@ export class RegistryServiceApiInMemory implements IRegistryServiceApi {
         for (shellDescriptor of this.registryShellDescriptorEntries) {
             if (shellDescriptor.id === aasId) {
                 const response = new Response(JSON.stringify(shellDescriptor));
-                const value = await WrapResponse<AssetAdministrationShellDescriptor>(response);
+                const value = await wrapResponse<AssetAdministrationShellDescriptor>(response);
                 return Promise.resolve(value);
             }
         }
-        return Promise.resolve(WrapErrorCode(ApiResultStatus.NOT_FOUND, 'no shell descriptor for aasId:' + aasId));
+        return Promise.resolve(wrapErrorCode(ApiResultStatus.NOT_FOUND, 'no shell descriptor for aasId:' + aasId));
     }
 
     async getAssetAdministrationShellFromEndpoint(
@@ -44,13 +44,13 @@ export class RegistryServiceApiInMemory implements IRegistryServiceApi {
         let registryEndpoint: INullableAasRegistryEndpointEntries;
         for (registryEndpoint of this.shellsAvailableOnEndpoints) {
             if (registryEndpoint.endpoint.toString() === endpoint.toString()) {
-                const value = await WrapResponse<AssetAdministrationShell>(
+                const value = await wrapResponse<AssetAdministrationShell>(
                     new Response(JSON.stringify(registryEndpoint.aas)),
                 );
                 return Promise.resolve(value);
             }
         }
-        return Promise.resolve(WrapErrorCode(ApiResultStatus.NOT_FOUND, 'no shell for url:' + endpoint));
+        return Promise.resolve(wrapErrorCode(ApiResultStatus.NOT_FOUND, 'no shell for url:' + endpoint));
     }
 
     async putAssetAdministrationShellDescriptorById(

--- a/src/lib/api/registry-service-api/registryServiceApiInMemory.ts
+++ b/src/lib/api/registry-service-api/registryServiceApiInMemory.ts
@@ -1,7 +1,7 @@
 import { IRegistryServiceApi } from 'lib/api/registry-service-api/registryServiceApiInterface';
 import { AssetAdministrationShellDescriptor } from 'lib/types/registryServiceTypes';
 import { AssetAdministrationShell } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
-import { ApiResponseWrapper, ApiResponseWrapperUtil, ApiResultStatus } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapResponse } from 'lib/services/apiResponseWrapper';
 
 export interface INullableAasRegistryEndpointEntries {
     endpoint: URL | string;
@@ -30,13 +30,11 @@ export class RegistryServiceApiInMemory implements IRegistryServiceApi {
         for (shellDescriptor of this.registryShellDescriptorEntries) {
             if (shellDescriptor.id === aasId) {
                 const response = new Response(JSON.stringify(shellDescriptor));
-                const value = await ApiResponseWrapperUtil.fromResponse<AssetAdministrationShellDescriptor>(response);
+                const value = await WrapResponse<AssetAdministrationShellDescriptor>(response);
                 return Promise.resolve(value);
             }
         }
-        return Promise.resolve(
-            ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'no shell descriptor for aasId:' + aasId),
-        );
+        return Promise.resolve(WrapErrorCode(ApiResultStatus.NOT_FOUND, 'no shell descriptor for aasId:' + aasId));
     }
 
     async getAssetAdministrationShellFromEndpoint(
@@ -46,15 +44,13 @@ export class RegistryServiceApiInMemory implements IRegistryServiceApi {
         let registryEndpoint: INullableAasRegistryEndpointEntries;
         for (registryEndpoint of this.shellsAvailableOnEndpoints) {
             if (registryEndpoint.endpoint.toString() === endpoint.toString()) {
-                const value = await ApiResponseWrapperUtil.fromResponse<AssetAdministrationShell>(
+                const value = await WrapResponse<AssetAdministrationShell>(
                     new Response(JSON.stringify(registryEndpoint.aas)),
                 );
                 return Promise.resolve(value);
             }
         }
-        return Promise.resolve(
-            ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'no shell for url:' + endpoint),
-        );
+        return Promise.resolve(WrapErrorCode(ApiResultStatus.NOT_FOUND, 'no shell for url:' + endpoint));
     }
 
     async putAssetAdministrationShellDescriptorById(

--- a/src/lib/api/registry-service-api/registryServiceApiInterface.ts
+++ b/src/lib/api/registry-service-api/registryServiceApiInterface.ts
@@ -1,6 +1,6 @@
 import { AssetAdministrationShellDescriptor } from 'lib/types/registryServiceTypes';
 import { AssetAdministrationShell } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export interface IRegistryServiceApi {
     baseUrl: string;

--- a/src/lib/api/serverFetch.ts
+++ b/src/lib/api/serverFetch.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { ApiResponseWrapper, ApiResponseWrapperUtil, ApiResultStatus } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapResponse } from 'lib/services/apiResponseWrapper';
 
 /**
  * @deprecated use performServerFetch() instead
@@ -21,10 +21,10 @@ export async function performServerFetch<T>(
 ): Promise<ApiResponseWrapper<T>> {
     try {
         const response = await fetch(input, init);
-        return ApiResponseWrapperUtil.fromResponse<T>(response);
+        return WrapResponse<T>(response);
     } catch (e) {
         const message = 'this could be a network error';
         console.warn(message);
-        return ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.UNKNOWN_ERROR, message);
+        return WrapErrorCode(ApiResultStatus.UNKNOWN_ERROR, message);
     }
 }

--- a/src/lib/api/serverFetch.ts
+++ b/src/lib/api/serverFetch.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapResponse } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, wrapErrorCode, wrapResponse } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 /**
  * @deprecated use performServerFetch() instead
@@ -21,10 +21,10 @@ export async function performServerFetch<T>(
 ): Promise<ApiResponseWrapper<T>> {
     try {
         const response = await fetch(input, init);
-        return WrapResponse<T>(response);
+        return wrapResponse<T>(response);
     } catch (e) {
         const message = 'this could be a network error';
         console.warn(message);
-        return WrapErrorCode(ApiResultStatus.UNKNOWN_ERROR, message);
+        return wrapErrorCode(ApiResultStatus.UNKNOWN_ERROR, message);
     }
 }

--- a/src/lib/api/submodel-registry-service/submodelRegistryServiceApi.ts
+++ b/src/lib/api/submodel-registry-service/submodelRegistryServiceApi.ts
@@ -1,5 +1,5 @@
 import { encodeBase64 } from 'lib/util/Base64Util';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { SubmodelDescriptor } from 'lib/types/registryServiceTypes';
 
 export class SubmodelRegistryServiceApi {

--- a/src/lib/services/apiResponseWrapper.spec.ts
+++ b/src/lib/services/apiResponseWrapper.spec.ts
@@ -1,10 +1,10 @@
-import { ApiResponseWrapperUtil, ApiResultStatus } from 'lib/services/apiResponseWrapper';
+import { ApiResultStatus, WrapErrorCode, WrapResponse, WrapSuccess } from 'lib/services/apiResponseWrapper';
 import { expect } from '@jest/globals';
 
 describe('', () => {
     it('transforms the http code to a success code', async () => {
         const response = new Response(JSON.stringify('dummy value'));
-        const successfulResponseWrapper = await ApiResponseWrapperUtil.fromResponse(response);
+        const successfulResponseWrapper = await WrapResponse(response);
         expect(successfulResponseWrapper.isSuccess).toBe(true);
         if (!successfulResponseWrapper.isSuccess) {
             expect(successfulResponseWrapper.errorCode).toBe(ApiResultStatus.SUCCESS);
@@ -13,7 +13,7 @@ describe('', () => {
 
     it('return data on success', async () => {
         const data = { name: 'John', age: 42 };
-        const responseWrapper = ApiResponseWrapperUtil.fromSuccess(data);
+        const responseWrapper = WrapSuccess(data);
 
         expect(responseWrapper.isSuccess).toBe(true);
         if (responseWrapper.isSuccess) {
@@ -23,7 +23,7 @@ describe('', () => {
 
     it('keep the error code', async () => {
         const message = 'something bad happened';
-        const responseWrapper = ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, message);
+        const responseWrapper = WrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, message);
 
         expect(responseWrapper.isSuccess).toBe(false);
         if (!responseWrapper.isSuccess) {

--- a/src/lib/services/apiResponseWrapper.ts
+++ b/src/lib/services/apiResponseWrapper.ts
@@ -33,37 +33,35 @@ export type ApiResponseWrapperError<T> = {
     message: string;
 };
 
-export class ApiResponseWrapperUtil {
-    static fromErrorCode<T>(error: ApiResultStatus, message: string): ApiResponseWrapperError<T> {
-        return {
-            isSuccess: false,
-            result: undefined,
-            errorCode: error,
-            message: message,
-        };
-    }
+export function WrapErrorCode<T>(error: ApiResultStatus, message: string): ApiResponseWrapperError<T> {
+    return {
+        isSuccess: false,
+        result: undefined,
+        errorCode: error,
+        message: message,
+    };
+}
 
-    static async fromResponse<T>(response: Response): Promise<ApiResponseWrapper<T>> {
-        const status = getStatus(response.status);
-        if (status === ApiResultStatus.SUCCESS) {
-            return {
-                isSuccess: true,
-                result: await response.json(),
-            };
-        } else {
-            return {
-                isSuccess: false,
-                result: await response.json(),
-                errorCode: status,
-                message: response.statusText,
-            };
-        }
-    }
-
-    static fromSuccess<T>(result: T): ApiResponseWrapper<T> {
+export async function WrapResponse<T>(response: Response): Promise<ApiResponseWrapper<T>> {
+    const status = getStatus(response.status);
+    if (status === ApiResultStatus.SUCCESS) {
         return {
             isSuccess: true,
-            result: result,
+            result: await response.json(),
+        };
+    } else {
+        return {
+            isSuccess: false,
+            result: await response.json(),
+            errorCode: status,
+            message: response.statusText,
         };
     }
+}
+
+export function WrapSuccess<T>(result: T): ApiResponseWrapper<T> {
+    return {
+        isSuccess: true,
+        result: result,
+    };
 }

--- a/src/lib/services/repository-access/RepositorySearchService.ts
+++ b/src/lib/services/repository-access/RepositorySearchService.ts
@@ -7,7 +7,7 @@ import { INullableAasRepositoryEntries } from 'lib/api/basyx-v3/apiInMemory';
 import { PrismaConnector } from 'lib/services/prisma/PrismaConnector';
 import { IPrismaConnector } from 'lib/services/prisma/PrismaConnectorInterface';
 import { Reference } from '@aas-core-works/aas-core3.0-typescript/types';
-import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapSuccess } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, wrapErrorCode, wrapSuccess } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 export type RepoSearchResult = {
     aas: AssetAdministrationShell;
@@ -61,13 +61,13 @@ export class RepositorySearchService {
     async getAasFromDefaultRepository(aasId: string): Promise<ApiResponseWrapper<AssetAdministrationShell>> {
         const response = await this.repositoryClient.getAssetAdministrationShellById(aasId);
         if (response.isSuccess) return response;
-        return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'AAS not found');
+        return wrapErrorCode(ApiResultStatus.NOT_FOUND, 'AAS not found');
     }
 
     async getAasFromRepo(aasId: string, repoUrl: string): Promise<ApiResponseWrapper<AssetAdministrationShell>> {
         const response = await this.repositoryClient.getAssetAdministrationShellById(aasId, undefined, repoUrl);
         if (response.isSuccess) return response;
-        return WrapErrorCode(ApiResultStatus.NOT_FOUND, `AAS '${aasId}' not found in repository '${repoUrl}'`);
+        return wrapErrorCode(ApiResultStatus.NOT_FOUND, `AAS '${aasId}' not found in repository '${repoUrl}'`);
     }
 
     async getAasFromAllRepos(aasId: string): Promise<ApiResponseWrapper<RepoSearchResult[]>> {
@@ -89,7 +89,7 @@ export class RepositorySearchService {
         );
 
         if (fulfilledResponses.length > 0) {
-            return WrapSuccess<RepoSearchResult[]>(
+            return wrapSuccess<RepoSearchResult[]>(
                 fulfilledResponses.map(
                     (
                         result: PromiseFulfilledResult<{
@@ -100,14 +100,14 @@ export class RepositorySearchService {
                 ),
             );
         } else {
-            return WrapErrorCode(ApiResultStatus.NOT_FOUND, `Could not find AAS ${aasId} in any Repository`);
+            return wrapErrorCode(ApiResultStatus.NOT_FOUND, `Could not find AAS ${aasId} in any Repository`);
         }
     }
 
     async getSubmodelById(id: string): Promise<ApiResponseWrapper<Submodel>> {
         const result = await this.submodelRepositoryClient.getSubmodelById(id);
         if (result.isSuccess) return result;
-        return WrapErrorCode(ApiResultStatus.NOT_FOUND, `Submodel with id ${id} not found`);
+        return wrapErrorCode(ApiResultStatus.NOT_FOUND, `Submodel with id ${id} not found`);
     }
 
     async getAttachmentFromSubmodelElement(
@@ -119,7 +119,7 @@ export class RepositorySearchService {
             submodelElementPath,
         );
         if (response.isSuccess) return response;
-        return WrapErrorCode(
+        return wrapErrorCode(
             ApiResultStatus.NOT_FOUND,
             `Attachment for Submodel with id ${submodelId} at path ${submodelElementPath} not found`,
         );
@@ -139,21 +139,21 @@ export class RepositorySearchService {
         try {
             return await Promise.any(promises);
         } catch (e) {
-            return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel not found');
+            return wrapErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel not found');
         }
     }
 
     async getSubmodelReferencesFromShell(aasId: string): Promise<ApiResponseWrapper<Reference[]>> {
         const response = await this.repositoryClient.getSubmodelReferencesFromShell(aasId);
         if (response.isSuccess) return response;
-        return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel Reference not found');
+        return wrapErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel Reference not found');
     }
 
     async getThumbnailFromShell(aasId: string): Promise<ApiResponseWrapper<Blob>> {
         const response = await this.repositoryClient.getThumbnailFromShell(aasId);
         if (response.isSuccess) return response;
 
-        return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Thumbnail not found');
+        return wrapErrorCode(ApiResultStatus.NOT_FOUND, 'Thumbnail not found');
     }
 
     async getAasThumbnailFromAllRepos(aasId: string): Promise<ApiResponseWrapper<Blob>> {
@@ -174,7 +174,7 @@ export class RepositorySearchService {
         try {
             return await Promise.any(promises);
         } catch {
-            return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Image not found');
+            return wrapErrorCode(ApiResultStatus.NOT_FOUND, 'Image not found');
         }
     }
 }

--- a/src/lib/services/repository-access/RepositorySearchService.ts
+++ b/src/lib/services/repository-access/RepositorySearchService.ts
@@ -7,7 +7,7 @@ import { INullableAasRepositoryEntries } from 'lib/api/basyx-v3/apiInMemory';
 import { PrismaConnector } from 'lib/services/prisma/PrismaConnector';
 import { IPrismaConnector } from 'lib/services/prisma/PrismaConnectorInterface';
 import { Reference } from '@aas-core-works/aas-core3.0-typescript/types';
-import { ApiResponseWrapper, ApiResponseWrapperUtil, ApiResultStatus } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper, ApiResultStatus, WrapErrorCode, WrapSuccess } from 'lib/services/apiResponseWrapper';
 
 export type RepoSearchResult = {
     aas: AssetAdministrationShell;
@@ -61,16 +61,13 @@ export class RepositorySearchService {
     async getAasFromDefaultRepository(aasId: string): Promise<ApiResponseWrapper<AssetAdministrationShell>> {
         const response = await this.repositoryClient.getAssetAdministrationShellById(aasId);
         if (response.isSuccess) return response;
-        return ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'AAS not found');
+        return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'AAS not found');
     }
 
     async getAasFromRepo(aasId: string, repoUrl: string): Promise<ApiResponseWrapper<AssetAdministrationShell>> {
         const response = await this.repositoryClient.getAssetAdministrationShellById(aasId, undefined, repoUrl);
         if (response.isSuccess) return response;
-        return ApiResponseWrapperUtil.fromErrorCode(
-            ApiResultStatus.NOT_FOUND,
-            `AAS '${aasId}' not found in repository '${repoUrl}'`,
-        );
+        return WrapErrorCode(ApiResultStatus.NOT_FOUND, `AAS '${aasId}' not found in repository '${repoUrl}'`);
     }
 
     async getAasFromAllRepos(aasId: string): Promise<ApiResponseWrapper<RepoSearchResult[]>> {
@@ -92,7 +89,7 @@ export class RepositorySearchService {
         );
 
         if (fulfilledResponses.length > 0) {
-            return ApiResponseWrapperUtil.fromSuccess<RepoSearchResult[]>(
+            return WrapSuccess<RepoSearchResult[]>(
                 fulfilledResponses.map(
                     (
                         result: PromiseFulfilledResult<{
@@ -103,17 +100,14 @@ export class RepositorySearchService {
                 ),
             );
         } else {
-            return ApiResponseWrapperUtil.fromErrorCode(
-                ApiResultStatus.NOT_FOUND,
-                `Could not find AAS ${aasId} in any Repository`,
-            );
+            return WrapErrorCode(ApiResultStatus.NOT_FOUND, `Could not find AAS ${aasId} in any Repository`);
         }
     }
 
     async getSubmodelById(id: string): Promise<ApiResponseWrapper<Submodel>> {
         const result = await this.submodelRepositoryClient.getSubmodelById(id);
         if (result.isSuccess) return result;
-        return ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, `Submodel with id ${id} not found`);
+        return WrapErrorCode(ApiResultStatus.NOT_FOUND, `Submodel with id ${id} not found`);
     }
 
     async getAttachmentFromSubmodelElement(
@@ -125,7 +119,7 @@ export class RepositorySearchService {
             submodelElementPath,
         );
         if (response.isSuccess) return response;
-        return ApiResponseWrapperUtil.fromErrorCode(
+        return WrapErrorCode(
             ApiResultStatus.NOT_FOUND,
             `Attachment for Submodel with id ${submodelId} at path ${submodelElementPath} not found`,
         );
@@ -145,21 +139,21 @@ export class RepositorySearchService {
         try {
             return await Promise.any(promises);
         } catch (e) {
-            return ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel not found');
+            return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel not found');
         }
     }
 
     async getSubmodelReferencesFromShell(aasId: string): Promise<ApiResponseWrapper<Reference[]>> {
         const response = await this.repositoryClient.getSubmodelReferencesFromShell(aasId);
         if (response.isSuccess) return response;
-        return ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel Reference not found');
+        return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Submodel Reference not found');
     }
 
     async getThumbnailFromShell(aasId: string): Promise<ApiResponseWrapper<Blob>> {
         const response = await this.repositoryClient.getThumbnailFromShell(aasId);
         if (response.isSuccess) return response;
 
-        return ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'Thumbnail not found');
+        return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Thumbnail not found');
     }
 
     async getAasThumbnailFromAllRepos(aasId: string): Promise<ApiResponseWrapper<Blob>> {
@@ -180,7 +174,7 @@ export class RepositorySearchService {
         try {
             return await Promise.any(promises);
         } catch {
-            return ApiResponseWrapperUtil.fromErrorCode(ApiResultStatus.NOT_FOUND, 'Image not found');
+            return WrapErrorCode(ApiResultStatus.NOT_FOUND, 'Image not found');
         }
     }
 }

--- a/src/lib/services/repository-access/repositorySearchActions.ts
+++ b/src/lib/services/repository-access/repositorySearchActions.ts
@@ -3,7 +3,7 @@
 import { AssetAdministrationShell, Submodel } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
 import { RepoSearchResult, RepositorySearchService } from 'lib/services/repository-access/RepositorySearchService';
 import { Reference } from '@aas-core-works/aas-core3.0-typescript/types';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 const searcher = RepositorySearchService.create();
 

--- a/src/lib/services/search-actions/searchActions.ts
+++ b/src/lib/services/search-actions/searchActions.ts
@@ -2,7 +2,7 @@
 
 import { AasSearcher, AasSearchResult } from 'lib/services/search-actions/AasSearcher';
 import { AssetAdministrationShell } from '@aas-core-works/aas-core3.0-typescript/dist/types/types';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { mnestixFetch } from 'lib/api/infrastructure';
 

--- a/src/lib/services/submodelRegistryApiActions.ts
+++ b/src/lib/services/submodelRegistryApiActions.ts
@@ -3,7 +3,7 @@
 import { mnestixFetch } from 'lib/api/infrastructure';
 import { SubmodelRegistryServiceApi } from 'lib/api/submodel-registry-service/submodelRegistryServiceApi';
 import { SubmodelDescriptor } from 'lib/types/registryServiceTypes';
-import { ApiResponseWrapper } from 'lib/services/apiResponseWrapper';
+import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 
 const submodelRegistryServiceClient = new SubmodelRegistryServiceApi(
     mnestixFetch(),

--- a/src/lib/util/apiResponseWrapper/apiResponseWrapper.spec.ts
+++ b/src/lib/util/apiResponseWrapper/apiResponseWrapper.spec.ts
@@ -1,10 +1,10 @@
-import { ApiResultStatus, WrapErrorCode, WrapResponse, WrapSuccess } from 'lib/services/apiResponseWrapper';
+import { ApiResultStatus, wrapErrorCode, wrapResponse, wrapSuccess } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { expect } from '@jest/globals';
 
 describe('', () => {
     it('transforms the http code to a success code', async () => {
         const response = new Response(JSON.stringify('dummy value'));
-        const successfulResponseWrapper = await WrapResponse(response);
+        const successfulResponseWrapper = await wrapResponse(response);
         expect(successfulResponseWrapper.isSuccess).toBe(true);
         if (!successfulResponseWrapper.isSuccess) {
             expect(successfulResponseWrapper.errorCode).toBe(ApiResultStatus.SUCCESS);
@@ -13,7 +13,7 @@ describe('', () => {
 
     it('return data on success', async () => {
         const data = { name: 'John', age: 42 };
-        const responseWrapper = WrapSuccess(data);
+        const responseWrapper = wrapSuccess(data);
 
         expect(responseWrapper.isSuccess).toBe(true);
         if (responseWrapper.isSuccess) {
@@ -23,7 +23,7 @@ describe('', () => {
 
     it('keep the error code', async () => {
         const message = 'something bad happened';
-        const responseWrapper = WrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, message);
+        const responseWrapper = wrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, message);
 
         expect(responseWrapper.isSuccess).toBe(false);
         if (!responseWrapper.isSuccess) {

--- a/src/lib/util/apiResponseWrapper/apiResponseWrapper.ts
+++ b/src/lib/util/apiResponseWrapper/apiResponseWrapper.ts
@@ -33,7 +33,7 @@ export type ApiResponseWrapperError<T> = {
     message: string;
 };
 
-export function WrapErrorCode<T>(error: ApiResultStatus, message: string): ApiResponseWrapperError<T> {
+export function wrapErrorCode<T>(error: ApiResultStatus, message: string): ApiResponseWrapperError<T> {
     return {
         isSuccess: false,
         result: undefined,
@@ -42,7 +42,7 @@ export function WrapErrorCode<T>(error: ApiResultStatus, message: string): ApiRe
     };
 }
 
-export async function WrapResponse<T>(response: Response): Promise<ApiResponseWrapper<T>> {
+export async function wrapResponse<T>(response: Response): Promise<ApiResponseWrapper<T>> {
     const status = getStatus(response.status);
     if (status === ApiResultStatus.SUCCESS) {
         return {
@@ -59,7 +59,7 @@ export async function WrapResponse<T>(response: Response): Promise<ApiResponseWr
     }
 }
 
-export function WrapSuccess<T>(result: T): ApiResponseWrapper<T> {
+export function wrapSuccess<T>(result: T): ApiResponseWrapper<T> {
     return {
         isSuccess: true,
         result: result,


### PR DESCRIPTION
# Description

Just a small change to get rid of a Util class and export the static functions directly

Fixes # (MNES-1223)

## Type of change

-   [x] Minor change (non-breaking change, e.g. documentation adaption)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
