### PR TITLE
fix(transfer-service): response for thumbnail transfer based on actual file transfer

### DIFF
--- a/src/lib/services/transfer-service/TransferService.ts
+++ b/src/lib/services/transfer-service/TransferService.ts
@@ -244,16 +244,30 @@ export class TransferService {
         if (isSuccessWithFile(response)) {
             const aasThumbnail = base64ToBlob(response.result, response.fileType);
             const fileName = ['thumbnail', generateRandomId()].join('');
-            await this.targetAasRepositoryClient.putThumbnailToShell(targetAasId, aasThumbnail, fileName, {
-                headers: {
-                    Apikey: apikey,
+            const pushResponse = await this.targetAasRepositoryClient.putThumbnailToShell(
+                targetAasId,
+                aasThumbnail,
+                fileName,
+                {
+                    headers: {
+                        Apikey: apikey,
+                    },
                 },
-            });
-            return { success: true, operationKind: 'AasRepository', resourceId: 'Thumbnail transfer.', error: '' };
+            );
+            if (pushResponse.isSuccess) {
+                return { success: true, operationKind: 'File transfer', resourceId: 'Thumbnail transfer.', error: '' };
+            } else {
+                return {
+                    success: false,
+                    operationKind: 'File transfer',
+                    resourceId: 'Thumbnail transfer.',
+                    error: pushResponse.message,
+                };
+            }
         } else {
             return {
                 success: false,
-                operationKind: 'AasRepository',
+                operationKind: 'File transfer',
                 resourceId: 'Thumbnail transfer.',
                 error: (response as ApiResponseWrapperError<Blob>).message,
             };


### PR DESCRIPTION
# Description

The result of the thumbnail TransferResult is based on the actual ApiResponseWrapper used to copy the thumbnail.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
