### PR TITLE
fix(pipeline): pass apikey in cypress tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'cypress';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 export default defineConfig({
     defaultCommandTimeout: 150000, // 150

--- a/cypress/e2e/thumbnailFileTest.spec.js
+++ b/cypress/e2e/thumbnailFileTest.spec.js
@@ -1,105 +1,95 @@
 ﻿import resolutions from '../fixtures/resolutions';
 import thumbnailAasMockData from '../fixtures/cypress_e2e/ThumbnailFileMockData/thumbnailAasMockData.json';
 
-describe('Thumbnail image as a file loaded test', function () {
-    before(function () {
-        cy.postTestThumbnailAas();
-        cy.uploadThumbnailToAas(thumbnailAasMockData.id);
-    });
+resolutions.forEach((res) => {
+    describe(`Resolution: ${res}`, function () {
+        describe('Thumbnail image as a file loaded test', function () {
+            before(function () {
+                cy.postTestThumbnailAas();
+                cy.uploadThumbnailToAas(thumbnailAasMockData.id);
+            });
 
-    resolutions.forEach((res) => {
-        it('should load thumbnail from file and visualize it in detail view (Resolution: ' + res + ')', function () {
-            cy.setResolution(res);
-            cy.visitViewer(thumbnailAasMockData.id).wait(5000);
-            cy.getByTestId('default-thumbnail-image-with-fallback', { timeout: 1000 }).should('not.exist');
-            cy.getByTestId('image-with-fallback', { timeout: 1000 })
-                .should('exist')
-                .should('be.visible')
-                .and((img) => {
-                    expect(img[0].naturalWidth).to.be.greaterThan(0);
-                    expect(img[0].naturalHeight).to.be.greaterThan(0);
-                });
+            it('should load thumbnail from file and visualize it in detail view', function () {
+                cy.setResolution(res);
+                cy.visitViewer(thumbnailAasMockData.id).wait(5000);
+                cy.getByTestId('default-thumbnail-image-with-fallback', { timeout: 1000 }).should('not.exist');
+                cy.getByTestId('image-with-fallback', { timeout: 1000 })
+                    .should('exist')
+                    .should('be.visible')
+                    .and((img) => {
+                        expect(img[0].naturalWidth).to.be.greaterThan(0);
+                        expect(img[0].naturalHeight).to.be.greaterThan(0);
+                    });
+            });
+
+            it('should load thumbnail from file and visualize it in list view', function () {
+                cy.setResolution(res);
+                cy.visit('/list').wait(2000);
+                cy.get('[data-testid="list-row-https://mnestix.io/aas/thumbnail_1"]').as('testAas');
+                cy.get('@testAas')
+                    .findByTestId('image-with-fallback')
+                    .should('exist')
+                    .should('be.visible')
+                    .and((img) => {
+                        expect(img[0].naturalWidth).to.be.greaterThan(0);
+                        expect(img[0].naturalHeight).to.be.greaterThan(0);
+                    });
+                cy.get('@testAas').findByTestId('default-thumbnail-image-with-fallback').should('not.exist');
+            });
+
+            it('should load thumbnail from file and visualize it in compare view', function () {
+                cy.visitViewer(thumbnailAasMockData.id);
+                cy.getByTestId('detail-compare-button').click();
+                cy.getByTestId('compare-aas-0')
+                    .findByTestId('image-with-fallback')
+                    .wait(2000)
+                    .should('exist')
+                    .should('be.visible')
+                    .and((img) => {
+                        expect(img[0].naturalWidth).to.be.greaterThan(0);
+                        expect(img[0].naturalHeight).to.be.greaterThan(0);
+                    });
+                cy.getByTestId('compare-aas-0')
+                    .findByTestId('default-thumbnail-image-with-fallback')
+                    .should('not.exist');
+            });
+
+            after(function () {
+                cy.deleteThumbnailFromAas(thumbnailAasMockData.id);
+                cy.deleteTestThumbnailAas();
+            });
         });
-        it('should load thumbnail from file and visualize it in list view (Resolution: ' + res + ')', function () {
-            cy.setResolution(res);
-            cy.visit('/list').wait(2000);
-            cy.get('[data-testid="list-row-https://mnestix.io/aas/thumbnail_1"]').as('testAas');
-            cy.get('@testAas')
-                .findByTestId('image-with-fallback')
-                .should('exist')
-                .should('be.visible')
-                .and((img) => {
-                    expect(img[0].naturalWidth).to.be.greaterThan(0);
-                    expect(img[0].naturalHeight).to.be.greaterThan(0);
-                });
-            cy.get('@testAas').findByTestId('default-thumbnail-image-with-fallback').should('not.exist');
-        });
-    });
 
-    it(
-        'should load thumbnail from file and visualize it in compare view (Resolution: ' + resolutions[0] + ')',
-        function () {
-            cy.visitViewer(thumbnailAasMockData.id);
-            cy.getByTestId('detail-compare-button').click();
-            cy.getByTestId('compare-aas-0')
-                .findByTestId('image-with-fallback')
-                .wait(2000)
-                .should('exist')
-                .should('be.visible')
-                .and((img) => {
-                    expect(img[0].naturalWidth).to.be.greaterThan(0);
-                    expect(img[0].naturalHeight).to.be.greaterThan(0);
-                });
-            cy.getByTestId('compare-aas-0').findByTestId('default-thumbnail-image-with-fallback').should('not.exist');
-        },
-    );
+        describe('Thumbnail image as a file not loaded test', function () {
+            before(function () {
+                cy.postTestThumbnailAas();
+            });
 
-    after(function () {
-        cy.deleteThumbnailFromAas(thumbnailAasMockData.id);
-        cy.deleteTestThumbnailAas();
-    });
-});
-
-describe('Thumbnail image as a file not loaded test', function () {
-    before(function () {
-        cy.postTestThumbnailAas();
-    });
-
-    resolutions.forEach((res) => {
-        it(
-            'should not load thumbnail from file and show default image in detail view (Resolution: ' + res + ')',
-            function () {
+            it('should not load thumbnail from file and show default image in detail view', function () {
                 cy.setResolution(res);
                 cy.visitViewer(thumbnailAasMockData.id).wait(5000);
                 cy.getByTestId('default-thumbnail-image-with-fallback', { timeout: 1000 }).should('exist');
                 cy.getByTestId('image-with-fallback', { timeout: 1000 }).should('not.exist');
-            },
-        );
-        it(
-            'should not load thumbnail from file and show default image in list view (Resolution: ' + res + ')',
-            function () {
+            });
+
+            it('should not load thumbnail from file and show default image in list view', function () {
                 cy.setResolution(res);
                 cy.visit('/list').wait(2000);
                 cy.get('[data-testid="list-row-https://mnestix.io/aas/thumbnail_1"]').as('testAas');
                 cy.get('@testAas').findByTestId('image-with-fallback').should('not.exist');
                 cy.get('@testAas').findByTestId('default-thumbnail-image-with-fallback').should('exist');
-            },
-        );
-    });
+            });
 
-    it(
-        'should not load thumbnail from file and show default image in compare view (Resolution: ' +
-            resolutions[0] +
-            ')',
-        function () {
-            cy.visitViewer(thumbnailAasMockData.id);
-            cy.getByTestId('detail-compare-button').click().wait(2000);
-            cy.getByTestId('compare-aas-0').findByTestId('image-with-fallback').should('not.exist');
-            cy.getByTestId('compare-aas-0').findByTestId('default-thumbnail-image-with-fallback').should('exist');
-        },
-    );
+            it('should not load thumbnail from file and show default image in compare view', function () {
+                cy.visitViewer(thumbnailAasMockData.id);
+                cy.getByTestId('detail-compare-button').click().wait(2000);
+                cy.getByTestId('compare-aas-0').findByTestId('image-with-fallback').should('not.exist');
+                cy.getByTestId('compare-aas-0').findByTestId('default-thumbnail-image-with-fallback').should('exist');
+            });
 
-    after(function () {
-        cy.deleteTestThumbnailAas();
+            after(function () {
+                cy.deleteTestThumbnailAas();
+            });
+        });
     });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -169,6 +169,9 @@ Cypress.Commands.add('uploadThumbnailToAas', (aasId: string) => {
                     '/asset-information/thumbnail?fileName=test_thumbnail.png',
                 body: formData,
                 encoding: 'binary',
+                headers: {
+                    ApiKey: Cypress.env('MNESTIX_API_KEY'),
+                }
             });
         });
 });

--- a/docker-compose/compose.test.yml
+++ b/docker-compose/compose.test.yml
@@ -10,6 +10,7 @@ services:
       CYPRESS_SUBMODEL_REPO_API_URL: 'http://mnestix-api:5064/repo'
       CYPRESS_MNESTIX_BACKEND_API_URL: 'http://mnestix-api:5064'
       CYPRESS_AAS_DISCOVERY_API_URL: 'http://mnestix-api:5064/discovery'
+      MNESTIX_BACKEND_API_KEY: ${MNESTIX_BACKEND_API_KEY:-verySecureApiKey}
       ELECTRON_ENABLE_LOGGING: 1
     volumes:
       - ./cypress-artifacts/screenshots:/cypress_Tests/cypress/screenshots

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "cypress": "^13.8.0",
         "cypress-junit-reporter": "^1.3.1",
         "cypress-msal-login": "^2.0.1",
+        "dotenv": "^16.4.5",
         "eslint-config-next": "14.2.3",
         "eslint-plugin-cypress": "^3.0.0",
         "eslint-plugin-formatjs": "^4.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,6 +4372,11 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 earcut@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"


### PR DESCRIPTION
# Description

cypress now uses the API key from .env for all tests

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
- 