### PR TITLE
fix: copying submodels by value instead of reference when transfering

### DIFF
--- a/src/app/[locale]/viewer/_components/transfer/TransferDialog.tsx
+++ b/src/app/[locale]/viewer/_components/transfer/TransferDialog.tsx
@@ -47,7 +47,7 @@ export function TransferDialog(props: DialogProps) {
         }
 
         // As long as we cannot adjust the IDs in the UI, we append '_copy' to every ID
-        const submodelsToTransfer = submodelsFromContext
+        const submodelsToTransfer = structuredClone(submodelsFromContext)
             .filter((sub) => sub.submodel)
             .map((sub) => sub.submodel!)
             .map((sub) => {


### PR DESCRIPTION
# Description

Problem: When transfering an AAS, the submodels displayed for the original AAS changed in the UI. That was due to us copying the submodels by reference instead of by value.

Fixes # (Issue)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
