### PR TITLE
fix(turbo mode): add legacy dev as debug launch config

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
         "string-width": "4.2.3"
     },
     "scripts": {
-        "dev": "yarn prisma migrate deploy && yarn prisma generate && next dev --turbo",
+        "dev": "yarn prisma migrate deploy && yarn prisma generate && next dev",
+        "turbo": "yarn prisma migrate deploy && yarn prisma generate && next dev --turbo",
         "build": "next build",
         "start": "yarn prisma migrate deploy && yarn prisma generate && next start",
         "prettier": "prettier --check ./",

--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
         "string-width": "4.2.3"
     },
     "scripts": {
-        "dev": "yarn prisma migrate deploy && yarn prisma generate && next dev",
-        "turbo": "yarn prisma migrate deploy && yarn prisma generate && next dev --turbo",
+        "dev": "yarn prisma migrate deploy && yarn prisma generate && next dev --turbo",
+        "debug": "yarn prisma migrate deploy && yarn prisma generate && next dev",
         "build": "next build",
         "start": "yarn prisma migrate deploy && yarn prisma generate && next start",
         "prettier": "prettier --check ./",


### PR DESCRIPTION
# Description

Unfortunately turbo mode does not always work smoothly with debugging.
I have added a debug configuration to launch the browser without the turbo mode

## Type of change

-   [x] Minor change (non-breaking change, e.g. documentation adaption)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
